### PR TITLE
Feat: 팀 프로필 사진 업 & 다운로드 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store:4.0.0-RC1'
+    implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:4.0.0-RC1')
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-h2console'

--- a/src/main/java/com/cloudintroteam/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/cloudintroteam/config/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.cloudintroteam.config;
 
+import com.cloudintroteam.member.exception.FileUploadFailedException;
 import com.cloudintroteam.member.exception.MemberNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -17,16 +18,24 @@ public class GlobalExceptionHandler {
     // 입력 검증 실패 에러
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, Object>> handleValidationException(MethodArgumentNotValidException ex) {
-        String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
         log.error("입력 검증 실패로 인한 에러 발생");
+        String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
         return getErrorResponse(HttpStatus.BAD_REQUEST, errorMessage);
     }
 
     // 팀원 not found 에러
     @ExceptionHandler(MemberNotFoundException.class)
     public ResponseEntity<Map<String, Object>> handleMemberNotFoundException(MemberNotFoundException ex) {
-        HttpStatus status = HttpStatus.NOT_FOUND;
         log.error("잘못된 팀원 조회 요청으로 인한 에러 발생");
+        HttpStatus status = HttpStatus.NOT_FOUND;
+        return getErrorResponse(status, ex.getMessage());
+    }
+
+    // 팀원 프로필 사진 업로드 실패 에러
+    @ExceptionHandler(FileUploadFailedException.class)
+    public ResponseEntity<Map<String, Object>> handleFileUploadFailedException(FileUploadFailedException ex) {
+        log.error("이미지 파일 업로드 과정에서 에러 발생");
+        HttpStatus status = HttpStatus.BAD_REQUEST;
         return getErrorResponse(status, ex.getMessage());
     }
 

--- a/src/main/java/com/cloudintroteam/member/controller/MemberController.java
+++ b/src/main/java/com/cloudintroteam/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.cloudintroteam.member.controller;
 
 import com.cloudintroteam.member.dto.request.SaveMemberRequest;
+import com.cloudintroteam.member.dto.response.FileDownloadResponse;
 import com.cloudintroteam.member.dto.response.GetMemberResponse;
 import com.cloudintroteam.member.dto.response.SaveMemberResponse;
 import com.cloudintroteam.member.service.MemberService;
@@ -40,5 +41,12 @@ public class MemberController {
         log.info("[API - LOG] 팀원 프로필 사진 저장 및 업로드 요청");
         memberService.upload(memberId, file);
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    // 팀원 프로필 사진 조회 및 다운로드
+    @GetMapping("/api/members/{memberId}/profile-image")
+    public ResponseEntity<FileDownloadResponse> fileDownload(@PathVariable Long memberId) {
+        log.info("[API - LOG] 팀원 프로필 사진 조회 및 다운로드 요청");
+        return ResponseEntity.status(HttpStatus.OK).body(memberService.download(memberId));
     }
 }

--- a/src/main/java/com/cloudintroteam/member/controller/MemberController.java
+++ b/src/main/java/com/cloudintroteam/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,5 +30,15 @@ public class MemberController {
     public ResponseEntity<GetMemberResponse> getMember(@PathVariable Long memberId) {
         log.info("[API - LOG] 팀원 조회 요청");
         return ResponseEntity.status(HttpStatus.OK).body(memberService.get(memberId));
+    }
+
+    // 팀원 프로필 사진 저장 및 업로드
+    @PostMapping("/api/members/{memberId}/profile-image")
+    public ResponseEntity<Void> fileUpload(
+            @PathVariable Long memberId,
+            @RequestParam("file")MultipartFile file) {
+        log.info("[API - LOG] 팀원 프로필 사진 저장 및 업로드 요청");
+        memberService.upload(memberId, file);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/cloudintroteam/member/dto/response/FileDownloadResponse.java
+++ b/src/main/java/com/cloudintroteam/member/dto/response/FileDownloadResponse.java
@@ -1,0 +1,12 @@
+package com.cloudintroteam.member.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class FileDownloadResponse {
+    private final String url;
+
+    public FileDownloadResponse(String url) {
+        this.url = url;
+    }
+}

--- a/src/main/java/com/cloudintroteam/member/entity/Member.java
+++ b/src/main/java/com/cloudintroteam/member/entity/Member.java
@@ -24,9 +24,16 @@ public class Member {
     @Column(nullable = false)
     private Mbti mbti;
 
+    @Column
+    private String imageKey;
+
     public Member(String name, int age, Mbti mbti) {
         this.name = name;
         this.age = age;
         this.mbti = mbti;
+    }
+
+    public void saveProfileImage(String imageKey) {
+        this.imageKey = imageKey;
     }
 }

--- a/src/main/java/com/cloudintroteam/member/exception/FileUploadFailedException.java
+++ b/src/main/java/com/cloudintroteam/member/exception/FileUploadFailedException.java
@@ -1,0 +1,7 @@
+package com.cloudintroteam.member.exception;
+
+public class FileUploadFailedException extends RuntimeException {
+    public FileUploadFailedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/cloudintroteam/member/service/MemberService.java
+++ b/src/main/java/com/cloudintroteam/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.cloudintroteam.member.service;
 
 import com.cloudintroteam.member.dto.request.SaveMemberRequest;
+import com.cloudintroteam.member.dto.response.FileDownloadResponse;
 import com.cloudintroteam.member.dto.response.GetMemberResponse;
 import com.cloudintroteam.member.dto.response.SaveMemberResponse;
 import com.cloudintroteam.member.entity.Member;
@@ -15,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.URL;
+import java.time.Duration;
 import java.util.UUID;
 
 @Service
@@ -76,5 +79,17 @@ public class MemberService {
 
         // 프로필 사진 저장
         member.saveProfileImage(key);
+    }
+
+    // 팀원 프로필 사진 조회 및 다운로드
+    @Transactional(readOnly = true)
+    public FileDownloadResponse download(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new MemberNotFoundException("존재하지 않는 팀원입니다."));
+
+        // 유효기간 7일의 다운로드 가능한 url 생성
+        URL url = s3Template.createSignedGetURL(bucket, member.getImageKey(), Duration.ofDays(7));
+
+        return new FileDownloadResponse(url.toString());
     }
 }

--- a/src/main/java/com/cloudintroteam/member/service/MemberService.java
+++ b/src/main/java/com/cloudintroteam/member/service/MemberService.java
@@ -4,16 +4,27 @@ import com.cloudintroteam.member.dto.request.SaveMemberRequest;
 import com.cloudintroteam.member.dto.response.GetMemberResponse;
 import com.cloudintroteam.member.dto.response.SaveMemberResponse;
 import com.cloudintroteam.member.entity.Member;
+import com.cloudintroteam.member.exception.FileUploadFailedException;
 import com.cloudintroteam.member.exception.MemberNotFoundException;
 import com.cloudintroteam.member.repository.MemberRepository;
+import io.awspring.cloud.s3.S3Template;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final S3Template s3Template;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
 
     // 팀원 저장
     @Transactional
@@ -42,5 +53,28 @@ public class MemberService {
                 member.getName(),
                 member.getAge(),
                 member.getMbti());
+    }
+
+    // 팀원 프로필 사진 저장 및 업로드
+    @Transactional
+    public void upload(Long memberId, MultipartFile file) {
+        if(file.isEmpty()) {
+            throw new FileUploadFailedException("저장할 이미지가 없습니다.");
+        }
+
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new MemberNotFoundException("존재하지 않는 팀원입니다."));
+
+        String key = "uploads/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+        // 프로필 사진 업로드
+        try {
+            s3Template.upload(bucket, key, file.getInputStream());
+        } catch (IOException e) {
+            throw new FileUploadFailedException("파일 업로드에 실패했습니다.");
+        }
+
+        // 프로필 사진 저장
+        member.saveProfileImage(key);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,15 @@
 spring:
   application:
     name: cloud-intro-team
+  cloud:
+    aws:
+      region:
+        static: ap-northeast-2
+      s3:
+        bucket: cloud-intro-team-praha1030-files
+  servlet:
+    multipart:
+      max-file-size: 10MB
 
 server:
   port: 8080


### PR DESCRIPTION
## 📝 작업 내용
- S3 버킷 생성
- S3 라이브러리 추가 (parameter store 라이브러리와 같이 BOM으로 관리)
- S3 사용 가능한 정책 추가한 IAM Role을 EC2에 연결
- 팀원 프로필 사진을 S3에 업로드하고, DB에 저장하는 기능 추가
- 팀원 프로피 사진을 조회하고 다운할 수 있는 기능 추가 (다운로드 가능한 URL의 유효기간은 7일)

## 🔗 관련 이슈 (Related Issues)
Closes #6 
Closes #7 

## ✅ 체크리스트 (Checklist)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 메서드/클래스 네이밍이 적절한가요?
- [ ] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 포스트맨을 통한 API 동작을 확인했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항